### PR TITLE
Remove startup delay and bump mem for es

### DIFF
--- a/srl-elk.clab.yml
+++ b/srl-elk.clab.yml
@@ -68,12 +68,11 @@ topology:
       image: docker.elastic.co/elasticsearch/elasticsearch:7.17.7
       env:
         node.name: es01
-        cluster.name: es-docker-cluster
         discovery.type: single-node
-        bootstrap.memory_lock: "false"
-        ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+        ES_JAVA_OPTS: "-Xms1g -Xmx1g"
       binds:
-        - ./elk/elasticsearch_data01:/usr/share/elasticsearch/data
+        # - ./elk/elasticsearch_data01:/usr/share/elasticsearch/data
+        - elk/logstash/index-template.json:/tmp/index-template.json
       ports:
         - 9200:9200/tcp
     logstash:
@@ -87,7 +86,6 @@ topology:
         - ./elk/logstash/logs/:/logs/
       wait-for:
         - es01
-      startup-delay: 30
     kibana:
       kind: linux
       mgmt_ipv4: 172.22.22.12
@@ -98,7 +96,6 @@ topology:
         - 5601:5601/tcp
       wait-for:
         - es01
-      startup-delay: 60
     #
     # CLIENTS
     #


### PR DESCRIPTION
@azyablov 
I had issues starting this lab on my machine.

First, I got access permissions failure for  `/elk/elasticsearch_data01:/usr/share/elasticsearch/data`. Why do we need this? To support index persistency between lab redeployments? What is your permissions then for this file?

mine:

```
❯ ls -la elk/elasticsearch_data01/es_data_volume 
-rw-r--r-- 1 root root 0 Feb  4 20:49 elk/elasticsearch_data01/es_data_volume
```

Secondly, I had to bump Java mem opts to 1Gi, as I saw in the logs it was complaining about mem starvation and that is what I found in various tutorials.


Third, do we need startup-delay between ELK nodes? I removed it to see if it works, and while the stack booted, my kibana UI was empty, I couldn't see any logs there. Maybe this is expected...